### PR TITLE
Update plugin versions for newer IntelliJ versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     id("org.jetbrains.kotlin.jvm") version "1.7.10"
 
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.8.0"
+    id("org.jetbrains.intellij") version "1.10.1"
 }
 
 group = properties("pluginGroup")

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion = 0.16.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 183
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
@@ -18,14 +18,14 @@ pluginUntilBuild = 222.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IU
-platformVersion = 2022.2.1
+platformVersion = 2022.3.2
 platformDownloadSources = true
 
 # TODO: Refactor it
-phpPluginVersion = 222.3739.61
-bladePluginVersion = 222.3739.61
+phpPluginVersion = 231.8109.51
+bladePluginVersion = 231.8109.51
 
-platformPlugins=com.jetbrains.php:222.3739.61,com.jetbrains.php.blade:222.3739.61,CSS,java-i18n,properties
+platformPlugins=com.jetbrains.php:231.8109.51,com.jetbrains.php.blade:231.8109.51,CSS,java-i18n,properties
 
 # Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
Not sure how to test/build this, but at least the version numbers should be correct for 2022.3.*